### PR TITLE
feat: reduce package size by removing Luxon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ node_js:
   - "8"
   - node
 
+env:
+  global:
+    - TZ=Europe/Paris
+
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ const { Logger } = require('@kocal/logger');
 const logger = Logger.getLogger();
 
 logger.debug('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET):: default :: debug :: My message`
+// Write `2019-01-15T12:30:10.000Z:: default :: debug :: My message`
 logger.log('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default :: log :: My message`
+// Write `2019-01-15T12:30:10.000Z :: default :: log :: My message`
 logger.info('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: info :: My message`
+// Write `2019-01-15T12:30:10.000Z :: info :: My message`
 logger.warn('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default :: warn :: My message`
+// Write `2019-01-15T12:30:10.000Z :: default :: warn :: My message`
 logger.error('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default :: error :: My message`
+// Write `2019-01-15T12:30:10.000Z :: default :: error :: My message`
 
 // Named logger
 const namedLogger = Logger.getLogger('my-name');
 
 namedLogger.debug('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: my-name :: debug :: My message`
+// Write `2019-01-15T12:30:10.000Z :: my-name :: debug :: My message`
 ```
 
 ### Custom level
@@ -77,7 +77,7 @@ logger.debug('Message');
 
 ### Custom format
 
-The default format is: `Date :: loggerName :: levelColor(level) :: message`.
+The default format is: `Date.toISOString() :: loggerName :: levelColor(level) :: message`.
 
 You can override the format at any moment by calling `logger.setFormat()`:
 
@@ -85,15 +85,15 @@ You can override the format at any moment by calling `logger.setFormat()`:
 const logger = Logger.getLogger();
 
 logger.format = (context, variables) => {
-  return `${context.date} :: ${context.message}`
+  return `${context.date.toISOString()} :: ${context.message}`
 }
 // or
 logger.setFormat((context, variables) => {
-    return `${context.date} :: ${context.message}`
+    return `${context.date.toISOString()} :: ${context.message}`
 })
 
 logger.log('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message`
+// Write `2019-01-15T12:30:10.000Z :: My message`
 ```
 
 ### Formatting the date
@@ -110,7 +110,7 @@ import { format as formatDate } from 'date-fns';
 
 const logger = Logger.getLogger();
 logger.format = (context, variables) => {
-  return `${formatDate(context.date, 'YYYY-MM-DD HH:mm:ss') :: ${context.message}`;
+  return `${formatDate(context.date, 'YYYY-MM-DD HH:mm:ss')} :: ${context.message}`;
 }
 
 logger.log('My message');
@@ -140,7 +140,7 @@ logger.setVariables({ count: 9000, foo: 'bar' })
 logger.setVariables(() => ({ count: 9000, foo: anotherVariable }))
 
 logger.log('My message');
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message :: vars = {"count":9000,"foo":"bar"}`
+// Write `2019-01-15T12:30:10.000Z :: My message :: vars = {"count":9000,"foo":"bar"}`
 ```
 
 ### Additional variables
@@ -150,11 +150,11 @@ All logs methods have a 2nd parameters where you can pass additional variables:
 ```js
 // pass a plain object
 logger.log('My message', { count: 1234 });
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message :: vars = {"count":1234,"foo":"bar"}`
+// Write `2019-01-15T12:30:10.000Z :: My message :: vars = {"count":1234,"foo":"bar"}`
 
 // or a function
 logger.log('My message', () => ({ count: 1234 }));
-// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message :: vars = {"count":1234,"foo":"bar"}`
+// Write `2019-01-15T12:30:10.000Z :: My message :: vars = {"count":1234,"foo":"bar"}`
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ const { Logger } = require('@kocal/logger');
 const logger = Logger.getLogger();
 
 logger.debug('My message');
-// Write `2018-02-17 08:55:28 :: default :: debug :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET):: default :: debug :: My message`
 logger.log('My message');
-// Write `2018-02-17 08:55:28 :: default :: log :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default :: log :: My message`
 logger.info('My message');
-// Write `2018-02-17 08:55:28 :: default :: info :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: info :: My message`
 logger.warn('My message');
-// Write `2018-02-17 08:55:28 :: default :: warn :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default :: warn :: My message`
 logger.error('My message');
-// Write `2018-02-17 08:55:28 :: default :: error :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default :: error :: My message`
 
 // Named logger
 const namedLogger = Logger.getLogger('my-name');
 
 namedLogger.debug('My message');
-// Write `2018-02-17 08:55:28 :: my-name :: debug :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: my-name :: debug :: My message`
 ```
 
 ### Custom level
@@ -77,7 +77,7 @@ logger.debug('Message');
 
 ### Custom format
 
-The default format is: `yyyy-LL-dd TT :: loggerName :: levelColor(level) :: message`.
+The default format is: `Date :: loggerName :: levelColor(level) :: message`.
 
 You can override the format at any moment by calling `logger.setFormat()`:
 
@@ -85,16 +85,38 @@ You can override the format at any moment by calling `logger.setFormat()`:
 const logger = Logger.getLogger();
 
 logger.format = (context, variables) => {
-  return `${context.luxon.toFormat('TT')} :: ${context.message}`
+  return `${context.date} :: ${context.message}`
 }
 // or
 logger.setFormat((context, variables) => {
-    return `${context.luxon.toFormat('TT')} :: ${context.message}`
+    return `${context.date} :: ${context.message}`
 })
 
 logger.log('My message');
-// Write `08:55:28 :: My message`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message`
 ```
+
+### Formatting the date
+
+In version 2.0, Luxon dependency has been removed because its weight is about ~85kB,
+and ~77% of the size of the logger is due to Luxon.
+
+
+To format the date, you can use [date-fns `format` method](https://date-fns.org/v1.30.1/docs/format):
+
+```js
+import { Logger } from '@kocal/logger';
+import { format as formatDate } from 'date-fns';
+
+const logger = Logger.getLogger();
+logger.format = (context, variables) => {
+  return `${formatDate(context.date, 'YYYY-MM-DD HH:mm:ss') :: ${context.message}`;
+}
+
+logger.log('My message');
+// Write `2019-01-15 13:13:10 :: My message`
+```
+
 
 ### Variables
 
@@ -104,7 +126,7 @@ You can specify static or dynamic variables like that:
 const logger = Logger.getLogger();
 
 logger.format = (context, variables) => {
-  return `${context.luxon.toFormat('TT')} :: ${context.message} :: vars = ${JSON.stringify(variables)}`;
+  return `${context.date} :: ${context.message} :: vars = ${JSON.stringify(variables)}`;
 }
 
 // pass a plain object
@@ -118,7 +140,7 @@ logger.setVariables({ count: 9000, foo: 'bar' })
 logger.setVariables(() => ({ count: 9000, foo: anotherVariable }))
 
 logger.log('My message');
-// Write `08:55:28 :: My message :: vars = {"count":9000,"foo":"bar"}`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message :: vars = {"count":9000,"foo":"bar"}`
 ```
 
 ### Additional variables
@@ -128,11 +150,11 @@ All logs methods have a 2nd parameters where you can pass additional variables:
 ```js
 // pass a plain object
 logger.log('My message', { count: 1234 });
-// Write `08:55:28 :: My message :: vars = {"count":1234,"foo":"bar"}`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message :: vars = {"count":1234,"foo":"bar"}`
 
 // or a function
 logger.log('My message', () => ({ count: 1234 }));
-// Write `08:55:28 :: My message :: vars = {"count":1234,"foo":"bar"}`
+// Write `Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: My message :: vars = {"count":1234,"foo":"bar"}`
 
 ```
 
@@ -159,7 +181,7 @@ Customize log messages format.
   - `context.levelColor`: the color that represents level
   - `context.message`: your message
   - `context.chalk`: an instance of [chalk](https://github.com/chalk/chalk)
-  - `context.luxon`: an instance of [luxon](https://github.com/moment/luxon)
+  - `context.date`: an instance of Date
 - `variables`: a fusion of variables defined with `.setVariables` and additional variables from logging methods
 
 ### `.debug( message, additionalVariables = {} | Function ): void`

--- a/__mocks__/luxon.js
+++ b/__mocks__/luxon.js
@@ -1,7 +1,0 @@
-const luxon = require('luxon');
-
-luxon.DateTime.local = function () {
-  return luxon.DateTime.fromISO('2018-02-17T08:30:00');
-};
-
-module.exports = luxon;

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
   },
   "homepage": "https://github.com/Kocal/logger#readme",
   "dependencies": {
-    "@types/luxon": "^1.10.2",
-    "chalk": "^2.4.1",
-    "luxon": "^1.8.2"
+    "chalk": "^2.4.1"
   },
   "devDependencies": {
     "@kocal/semantic-release-preset": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@kocal/semantic-release-preset": "^1.1.0",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.18",
+    "date-fns": "^1.30.1",
     "jest": "^23.6.0",
     "rimraf": "^2.6.3",
     "semantic-release": "^15.12.3",

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -1,5 +1,6 @@
 import Logger from '.';
 import chalk from 'chalk';
+import { format } from 'date-fns';
 
 describe('Logger', function () {
   beforeEach(() => {
@@ -17,44 +18,45 @@ describe('Logger', function () {
   });
 
   test('default format', () => {
+    const date = jest.spyOn(Date, 'now').mockImplementation(() => 1547555410000); // 2019-01-15 12:30:12
     const logger = Logger.getLogger('default-format');
     logger.setLevel('debug');
 
     logger.debug('Debug message');
-    expect(console.debug).toHaveBeenLastCalledWith(chalk`2018-02-17 08:30:00 :: default-format :: {cyanBright debug} :: Debug message`);
+    expect(console.debug).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {cyanBright debug} :: Debug message`);
 
     logger.log('Log message');
-    expect(console.log).toHaveBeenLastCalledWith(chalk`2018-02-17 08:30:00 :: default-format :: {green log} :: Log message`);
+    expect(console.log).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {green log} :: Log message`);
 
     logger.info('Info message');
-    expect(console.info).toHaveBeenLastCalledWith(chalk`2018-02-17 08:30:00 :: default-format :: {blue info} :: Info message`);
+    expect(console.info).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {blue info} :: Info message`);
 
     logger.warn('Warn message');
-    expect(console.warn).toHaveBeenLastCalledWith(chalk`2018-02-17 08:30:00 :: default-format :: {yellow warn} :: Warn message`);
+    expect(console.warn).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {yellow warn} :: Warn message`);
 
     logger.error('Error message');
-    expect(console.error).toHaveBeenLastCalledWith(chalk`2018-02-17 08:30:00 :: default-format :: {redBright error} :: Error message`);
+    expect(console.error).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {redBright error} :: Error message`);
   });
 
   test('custom format', () => {
     const logger = Logger.getLogger('custom-format');
     logger.setLevel('debug');
-    logger.setFormat((ctx, variables) => `${ctx.luxon.toFormat('yyyy-LL-dd')} - ${ctx.level} - ${ctx.message}`);
+    logger.setFormat((ctx, variables) => `${format(ctx.date, 'YYYY-MM-DD')} - ${ctx.level} - ${ctx.message}`);
 
     logger.debug('Debug message');
-    expect(console.debug).toHaveBeenLastCalledWith('2018-02-17 - debug - Debug message');
+    expect(console.debug).toHaveBeenLastCalledWith('2019-01-15 - debug - Debug message');
 
     logger.log('Log message');
-    expect(console.log).toHaveBeenLastCalledWith('2018-02-17 - log - Log message');
+    expect(console.log).toHaveBeenLastCalledWith('2019-01-15 - log - Log message');
 
     logger.info('Info message');
-    expect(console.info).toHaveBeenLastCalledWith('2018-02-17 - info - Info message');
+    expect(console.info).toHaveBeenLastCalledWith('2019-01-15 - info - Info message');
 
     logger.warn('Warn message');
-    expect(console.warn).toHaveBeenLastCalledWith('2018-02-17 - warn - Warn message');
+    expect(console.warn).toHaveBeenLastCalledWith('2019-01-15 - warn - Warn message');
 
     logger.error('Error message');
-    expect(console.error).toHaveBeenLastCalledWith('2018-02-17 - error - Error message');
+    expect(console.error).toHaveBeenLastCalledWith('2019-01-15 - error - Error message');
   });
 
   test('context variables', () => {

--- a/src/logger.test.ts
+++ b/src/logger.test.ts
@@ -23,19 +23,19 @@ describe('Logger', function () {
     logger.setLevel('debug');
 
     logger.debug('Debug message');
-    expect(console.debug).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {cyanBright debug} :: Debug message`);
+    expect(console.debug).toHaveBeenLastCalledWith(chalk`2019-01-15T12:30:10.000Z :: default-format :: {cyanBright debug} :: Debug message`);
 
     logger.log('Log message');
-    expect(console.log).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {green log} :: Log message`);
+    expect(console.log).toHaveBeenLastCalledWith(chalk`2019-01-15T12:30:10.000Z :: default-format :: {green log} :: Log message`);
 
     logger.info('Info message');
-    expect(console.info).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {blue info} :: Info message`);
+    expect(console.info).toHaveBeenLastCalledWith(chalk`2019-01-15T12:30:10.000Z :: default-format :: {blue info} :: Info message`);
 
     logger.warn('Warn message');
-    expect(console.warn).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {yellow warn} :: Warn message`);
+    expect(console.warn).toHaveBeenLastCalledWith(chalk`2019-01-15T12:30:10.000Z :: default-format :: {yellow warn} :: Warn message`);
 
     logger.error('Error message');
-    expect(console.error).toHaveBeenLastCalledWith(chalk`Tue Jan 15 2019 13:30:10 GMT+0100 (CET) :: default-format :: {redBright error} :: Error message`);
+    expect(console.error).toHaveBeenLastCalledWith(chalk`2019-01-15T12:30:10.000Z :: default-format :: {redBright error} :: Error message`);
   });
 
   test('custom format', () => {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import chalk, { Chalk } from 'chalk';
 import { Level, levels } from './levels';
 
@@ -13,7 +12,7 @@ export interface Context {
   name: string;
   chalk: Chalk;
   levelColor: Chalk;
-  luxon: DateTime;
+  date: Date;
 }
 
 export interface Options {
@@ -25,7 +24,7 @@ export interface Options {
 const loggers: { [k: string]: Logger } = {};
 
 const defaultFormat = (ctx: Context, variables: Variables) => {
-  return `${ctx.luxon.toFormat('yyyy-LL-dd TT')} :: ${ctx.name} :: ${ctx.levelColor(ctx.level)} :: ${ctx.message}`;
+  return `${ctx.date} :: ${ctx.name} :: ${ctx.levelColor(ctx.level)} :: ${ctx.message}`;
 };
 
 export class Logger {
@@ -91,7 +90,7 @@ export class Logger {
       message,
       chalk,
       name: this.name,
-      luxon: DateTime.local(),
+      date: new Date(Date.now()),
       levelColor: levels[level].color,
     };
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,7 +24,7 @@ export interface Options {
 const loggers: { [k: string]: Logger } = {};
 
 const defaultFormat = (ctx: Context, variables: Variables) => {
-  return `${ctx.date} :: ${ctx.name} :: ${ctx.levelColor(ctx.level)} :: ${ctx.message}`;
+  return `${ctx.date.toISOString()} :: ${ctx.name} :: ${ctx.levelColor(ctx.level)} :: ${ctx.message}`;
 };
 
 export class Logger {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,6 +1305,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.30.1:
+  version "1.30.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
+  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,11 +152,6 @@
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.13.tgz#c81484b6f4ca007bb09887ed15ecb3286d58f928"
   integrity sha512-ePl4l+7dLLmCucIwgQHAgjiepY++qcI6nb8eAwGNkB6OxmTe3Z9rQU3rSpomqu42PCCnlThZbOoxsf+qylJsLA==
 
-"@types/luxon@^1.10.2":
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-1.11.0.tgz#862041d849bafb991937f25f68d2ff0a4ca3f1e2"
-  integrity sha512-4MBC4fp+W+LJ7Abr03qJtJn2yS6sy9B9xgU+fEaWiIHYxRkFgLVl4WEsLK/dKYXe8VdWtLM4fED4HWaJpMnJMg==
-
 "@types/node@^10.12.18":
   version "10.12.24"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.24.tgz#b13564af612a22a20b5d95ca40f1bffb3af315cf"
@@ -3592,11 +3587,6 @@ lru-cache@^4.1.1, lru-cache@^4.1.2, lru-cache@^4.1.3:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
-
-luxon@^1.8.2:
-  version "1.11.2"
-  resolved "https://registry.yarnpkg.com/luxon/-/luxon-1.11.2.tgz#0073566e8b6f493d68891c6b871dd72196547c24"
-  integrity sha512-dD6sJotzprPhqJAp9eZbc1y1cc0CMiwRabsaEfFBJT2lRkWdOqJe3QmxB8GNwjOHZ6fciuGiLK3htgxZgphGxA==
 
 macos-release@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Ref: #66.

BREAKING CHANGES: Luxon dependency has been removed in order to reduce the package size. The date is not formatted anymore. If you still want too, you can install the package `date-fns` and configure your logger's format by using the [`format` method](https://date-fns.org/v1.30.1/docs/format) from `date-fns`. See the [doc](https://github.com/Kocal/logger/tree/feat%2Fremove-luxon#formatting-the-date) for more information.